### PR TITLE
修复 mteam 用户等级解析问题

### DIFF
--- a/site_config/sites/HDArea.json
+++ b/site_config/sites/HDArea.json
@@ -90,12 +90,6 @@
   },
   "requests": {
     "search": {
-      "parser": "CssSelector",
-      "method": "GET",
-      "path": "/torrents.php",
-      "params": {
-        "search": ["{keyword}"]
-      },
       "fields": {
         "description": {
           "selector": "td.embedded",
@@ -107,10 +101,6 @@
               "args": ["()", ""]
             }
           ]
-        },
-        "labels": {
-          "selector": "td.embedded > span[title]",
-          "array": true
         }
       }
     },

--- a/site_config/sites/mteam.json
+++ b/site_config/sites/mteam.json
@@ -299,6 +299,9 @@
         },
         "role": {
           "selector": "data.role"
+        },
+        "level": {
+          "selector": "data.role"
         }
       }
     },
@@ -351,7 +354,9 @@
         "selector": "data"
       },
       "fields": {
-        "id": {},
+        "id": {
+          "selector": "id"
+        },
         "name_chs": {
           "selector": "nameChs"
         },
@@ -359,6 +364,7 @@
           "selector": "nameEng"
         },
         "image": {
+          "selector": "image",
           "filters": [
             {
               "name": "append_left",


### PR DESCRIPTION
- 在 profile 请求中添加 level 字段，使用 data.role 选择器
- 优化 sys_role_list 配置，明确指定 id 和 image 字段的选择器
- 修复 HDArea.json 配置

现在系统可以正确解析并显示用户等级（如等级 9 对应"大臣"）