### PR TITLE
fix(haidan): 用通用登录检测替换硬编码用户名

### DIFF
--- a/site_config/sites/haidan.json
+++ b/site_config/sites/haidan.json
@@ -175,7 +175,29 @@
       "path": "/",
       "fields": {
         "is_login": {
-          "selector": "//a[contains(@href, \"userdetails.php?id=\") and contains(., \"xiaojunxiang\")]",
+          "any": [
+            {
+              "selector": "//a[contains(@href, 'logout')]/text()"
+            },
+            {
+              "selector": "//a[contains(@data-url, 'logout')]/text()"
+            },
+            {
+              "selector": "//a[contains(@href, 'mybonus')]/text()"
+            },
+            {
+              "selector": "//a[contains(@onclick, 'logout')]/text()"
+            },
+            {
+              "selector": "//a[contains(@href, 'usercp')]/text()"
+            },
+            {
+              "selector": "//form[contains(@action, 'logout')]/text()"
+            },
+            {
+              "selector": "//div[@class='user-info-side']/text()"
+            }
+          ],
           "filters": [
             {
               "name": "not_blank"


### PR DESCRIPTION
## 问题

haidan.json 的 `is_login` 检测器硬编码了适配器作者的测试用户名 `xiaojunxiang`, 导致其他用户 cookie 有效但 Media Saber 永远报"未登录", 签到无法完成。

## 修复

将 `is_login` 从固定用户名匹配改为通用登录特征检测(与 `site_config/commons/NexusPHP.json` 一致):

- `//a[contains(@href, "logout")]/text()`
- `//a[contains(@href, "mybonus")]/text()`
- `//a[contains(@href, "usercp")]/text()`
- 以及其他常见登录特征(any 匹配)

这样任意用户只要 cookie 有效就能被正确识别为已登录, 不再依赖特定账号。

## 验证

- 已用真实 cookie 验证 haidan 首页包含 `logout.php` / `mybonus.php` / `usercp.php` 链接, 通用选择器可正确匹配
- JSON 格式校验通过
- 在本地 media-saber 实测: 修改后签到返回 code=200 (今日已签到)